### PR TITLE
allow to pass vuex module options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,14 @@ import getters from './getters'
 import mutations from './mutations'
 import actions from './actions'
 
-export default (store, config, namespace = 'cognito') => {
+export default (store, config, namespace = 'cognito', vuexModuleOptions = {}) => {
   store.registerModule(namespace, {
     namespaced: true,
     actions,
     getters,
     mutations,
     state
-  })
+  }, vuexModuleOptions)
 
   store.dispatch(`${namespace}/init`, config)
 }


### PR DESCRIPTION
It is useful for ssr. Specifically preserveState option
https://vuex.vuejs.org/guide/modules.html#dynamic-module-registration

> It may be likely that you want to preserve the previous state when registering a new module, such as  preserving state from a Server Side Rendered app. You can do achieve this with preserveState option: store.registerModule('a', module, { preserveState: true })


